### PR TITLE
Fix CORS for local port 3001

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -23,6 +23,7 @@ allowed_origins = [
     "http://localhost:3000",
     "http://localhost:3001",
     "http://127.0.0.1:3000",
+    "http://127.0.0.1:3001",
     
     # Cloudflare Tunnels
     "https://riskyparity.blackboxinovacao.com.br",


### PR DESCRIPTION
## Summary
- allow frontend served from `http://127.0.0.1:3001` to access the API

## Testing
- `pytest -q`
- `npm test --silent` *(fails: react-scripts not found / network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685d82c6881c832196b5616f27991e38