### PR TITLE
Add root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Global ignores
+# Environment variables
+.env
+
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+*.egg
+.env/
+venv/
+.venv/
+
+# Node artifacts
+node_modules/
+
+# Build outputs
+build/
+dist/
+
+# Logs
+*.log
+
+# OS-generated files
+.DS_Store


### PR DESCRIPTION
## Summary
- add `.gitignore` at repository root to ignore common artifacts including Python caches, node modules, logs, builds, and `.env`

## Testing
- `python -m py_compile backend/*.py`
- `npm install` *(fails: 403 Forbidden)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7ffd8d08832196ac367238091e26